### PR TITLE
Numpy should be <= 2.1

### DIFF
--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -105,7 +105,7 @@ source ${HOME}/.venv/ISSM/bin/activate
 
 Then, use pip to install NumPy, SciPy, and dependencies,
 ```sh
-pip install matplotlib netcdf4 nose numpy pyshp scipy
+pip install matplotlib netcdf4 nose numpy=2.1 pyshp scipy
 ```
 
 Alternatively, copy and paste the following to achieve all of the above,


### PR DESCRIPTION
export_netCDF.py uses "np.reshape(self.data, newshape=(findim))". newshape= was deprecated in favor of shape= in numpy v2.1, removed in 2.3.

Alternate (better?) bug fix is to update export_netCDF.py, but then anyone pulling this change would need to update their python environment.